### PR TITLE
Fix translify of one croatian letter.

### DIFF
--- a/django_autoslug/fields.py
+++ b/django_autoslug/fields.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import re
 import datetime
 from django.template.defaultfilters import slugify
@@ -69,7 +70,7 @@ class AutoSlugField(SlugField):
     def slugify_func(self, content):
         try:
             from pytils.translit import translify
-            content = translify(content)
+            content = translify(content.replace(u'đ', 'd').replace(u'Đ', 'd'))
         except:
             pass
 


### PR DESCRIPTION
Đ -> d
đ -> d

It's not the best fix but it works. Ideally this change would be made in pytils.transilit.translify.TRANSTABLE from package pytils. (or to create TRANSTABLE for Croatian language)
